### PR TITLE
Add a Total Clients and Languages Widget

### DIFF
--- a/lib/phoenix_app_web/templates/team/index.html.heex
+++ b/lib/phoenix_app_web/templates/team/index.html.heex
@@ -15,6 +15,19 @@
       <div class="mb-8">
         <%= link "Get Listed", to: "https://github.com/w3f-webops/graypaper-website/issues/new?assignees=&labels=&projects=&template=client-listing-request.md&title=Client+Listing%3A+XYZ", class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded shadow-md transition duration-300 ease-in-out", target: "_blank" %>
       </div>
+      <div class="bg-gray-800 rounded-lg p-6 mb-8 shadow-lg border border-gray-700">
+        <div class="flex flex-col sm:flex-row justify-around items-center text-center">
+          <div class="mb-6 sm:mb-0">
+            <p class="text-4xl font-bold text-white"><%= length(@teams) %></p>
+            <p class="text-lg text-gray-400 mt-1">Total Teams</p>
+          </div>
+          <div class="hidden sm:block w-px h-16 bg-gray-700"></div>
+          <div>
+            <p class="text-4xl font-bold text-white"><%= @teams |> Enum.map(&(&1.lang)) |> Enum.uniq() |> length() %></p>
+            <p class="text-lg text-gray-400 mt-1">Unique Programming Languages</p>
+          </div>
+        </div>
+      </div>
       <div class="overflow-x-auto">
         <table class="min-w-full bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
           <thead>
@@ -22,7 +35,7 @@
               <th class="px-6 py-3 text-center text-xs font-medium text-gray-300 uppercase tracking-wider border-b border-gray-700">
                 <%= link to: Routes.team_path(@conn, :index, sort: "name", order: sort_order("name", @sort_by, @sort_order)), class: "flex items-center justify-center group" do %>
                   <span>Team Name</span>
-                  <span class="ml-2"> 
+                  <span class="ml-2">
                     <%= if @sort_by == "name" do %>
                       <%= if @sort_order == "asc" do %>
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path></svg>


### PR DESCRIPTION
Adds a new widget which shows the total number of clients, and the total number of unique programming languages:

<img width="1563" height="758" alt="image" src="https://github.com/user-attachments/assets/0328c9bc-c59d-4a4f-b490-974d69645d86" />


Information which I think is relevant to be easily seen.

cc @kianenigma @ggwpez 